### PR TITLE
Create Prisma Not Found Exception

### DIFF
--- a/src/exception-filters/prisma-not-found.exception.ts
+++ b/src/exception-filters/prisma-not-found.exception.ts
@@ -1,0 +1,26 @@
+import { ExceptionFilter, Catch, ArgumentsHost } from "@nestjs/common";
+import { Prisma } from "@prisma/client"
+import { Request, Response } from "express"
+
+@Catch(Prisma.PrismaClientKnownRequestError)
+export class PrismaNotFoundException implements ExceptionFilter {
+    catch(exception:Prisma.PrismaClientKnownRequestError, host:ArgumentsHost) {
+        const context = host.switchToHttp();
+        const request = context.getRequest<Request>();
+        const response = context.getResponse<Response>();
+
+        if(exception.code === 'P2025'){
+            response.status(404).json({
+                statusCode:404,
+                message:"Not Found",
+                path:request.url
+            });
+        }else{
+            response.status(500).json({
+                statusCode:500,
+                message:exception.code,
+                path:request.url
+            });
+        }
+    }
+}


### PR DESCRIPTION
Create the class to catch Prisma request errors to don't throw 500 when are a bad request 404. For exemple, not fount an id to update..